### PR TITLE
Respect `scrolloff` when scrolling window without moving the cursor

### DIFF
--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -80,7 +80,7 @@ M.setup = function(opts)
   end
   opts.disabled_modes = disabled_modes_hashmap
 
-  local autocmds = { 'CursorMoved' }
+  local autocmds = { 'CursorMoved', 'WinScrolled' }
   if opts.insert_mode then
     table.insert(autocmds, 'CursorMovedI')
   end


### PR DESCRIPTION
So that when we reach `EOF` and press `zb`, which will scroll the window but won't move the cursor, we still keep the `scrolloff`.