### PR TITLE
Fix window height calculation when winbar active

### DIFF
--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -30,7 +30,7 @@ local function check_eof_scrolloff()
     return
   end
 
-  local win_height = vim.api.nvim_win_get_height(0)
+  local win_height = vim.fn.winheight(0)
   local last_line = vim.fn.line('$')
   local win_last_line = vim.fn.line('w$')
 


### PR DESCRIPTION
Resolves #6 

`vim.api.nvim_win_get_height` returns the outer size of the window, as would be relevant for layout calculations. This means it's intended to include the space taken up by border elements such as the winbar. `vim.fn.winheight` should return the inner height of the window, excluding the size of the winbar.

Source: https://github.com/neovim/neovim/issues/18753

If this solution is acceptable, please consider adding the `hacktoberfest-accepted` label to this PR, so it will count toward my progress in the event :)