### PR TITLE
fix typo in default settings code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These are the default settings. Any changes can be made in the call to `setup`.
 require('scrollEOF').setup({
   -- The pattern used for the internal autocmd to determine
   -- where to run scrollEOF. See https://neovim.io/doc/user/autocmd.html#autocmd-pattern
-  pattern = '*'
+  pattern = '*',
   -- Whether or not scrollEOF should be enabled in insert mode
   insert_mode = false,
   -- Whether or not scrollEOF should be enabled in floating windows


### PR DESCRIPTION
I was wondering why the plugin did not install

I just simply copy pasted and found it was missing a comma