### PR TITLE
fix: `gg` `G` can cause the cursor position to show incorrectly

### DIFF
--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -30,7 +30,10 @@ local function check_eof_scrolloff(ev)
 
   if visual_distance_to_eof < scrolloff then
     local win_view = vim.fn.winsaveview()
-    vim.fn.winrestview({ topline = win_view.topline + scrolloff - visual_distance_to_eof })
+    vim.fn.winrestview({
+      skipcol = 0, -- Without this, `gg` `G` can cause the cursor position to be shown incorrectly
+      topline = win_view.topline + scrolloff - visual_distance_to_eof,
+    })
   end
 end
 


### PR DESCRIPTION
I'm not exactly sure why, but adding `skipcol = 0` to `vim.fn.winrestview()` appears to fix this. This is a parameter that's returned by `vim.fn.winsaveview()`.

Fixes #20.