### PR TITLE
fix(terminal): disable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ require('scrollEOF').setup({
   -- Whether or not scrollEOF should be enabled in floating windows
   floating = true,
   -- List of filetypes to disable scrollEOF for.
-  disabled_filetypes = {},
+  disabled_filetypes = { 'terminal' },
   -- List of modes to disable scrollEOF for. see https://neovim.io/doc/user/builtin.html#mode()
-  disabled_modes = {},
+  disabled_modes = { 't', 'nt' },
 })
 ```
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -42,8 +42,8 @@ local default_opts = {
   pattern = '*',
   insert_mode = false,
   floating = true,
-  disabled_filetypes = {},
-  disabled_modes = {},
+  disabled_filetypes = { 'terminal' },
+  disabled_modes = { 't', 'nt' },
 }
 
 local vim_resized_cb = function()


### PR DESCRIPTION
This plugin doesn't make sense to enable by default in the terminal as it can cause weird behaviour.