### PR TITLE
Fix negative scrolloff error

### DIFF
--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -67,7 +67,7 @@ local vim_resized_cb = function()
   end
 
   scrolloff = half_win_height
-  vim.o.scrolloff = win_height % 2 == 0 and scrolloff - 1 or scrolloff
+	vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
 end
 
 M.setup = function(opts)


### PR DESCRIPTION
I was getting this error periodically when opening a file from Neotree. Adding a check that `scrollOff > 0` here seems to have resolved the issue for me. Been running my fork of this for the past 3 weeks and haven't seen it since.

I don't know if this is the best way to resolve the issue, feel free to close the PR or modify as you see fit.

```
E5108: Error executing lua: ...hare/nvim/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:808: BufEnter Autocommands for "*": Vim(append):Error executing lua callback: .../.local/share/nvim/lazy/scrollEOF.nvim/lua/scrollEOF.lua:63: E487: Argument must be positive
stack traceback:
	[C]: in function '__newindex'
	.../.local/share/nvim/lazy/scrollEOF.nvim/lua/scrollEOF.lua:63: in function <.../.local/share/nvim/lazy/scrollEOF.nvim/lua/scrollEOF.lua:49>
	[C]: in function 'nvim_set_current_win'
	...hare/nvim/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:808: in function 'open_file'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:807: in function 'open'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:829: in function 'open_with_cmd'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:837: in function 'open'
	...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:204: in function <...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:203>
stack traceback:
	[C]: in function 'nvim_set_current_win'
	...hare/nvim/lazy/neo-tree.nvim/lua/neo-tree/utils/init.lua:808: in function 'open_file'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:807: in function 'open'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:829: in function 'open_with_cmd'
	...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:837: in function 'open'
	...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:204: in function <...o-tree.nvim/lua/neo-tree/sources/filesystem/commands.lua:203>
```