### PR TITLE
Add enabled filetypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ require('scrollEOF').setup({
   floating = true,
   -- List of filetypes to disable scrollEOF for.
   disabled_filetypes = { 'terminal' },
+  -- List of filetypes to enable scrollEOF for. 
+  -- When empty, scrollEOF is enabled for all filetypes except the disabled_filetypes.
+  -- When specified, scrollEOF is only enabled for the listed filetypes.
+  enabled_filetyles = {},
   -- List of modes to disable scrollEOF for. see https://neovim.io/doc/user/builtin.html#mode()
   disabled_modes = { 't', 'nt' },
 })
@@ -60,3 +64,4 @@ require('scrollEOF').setup({
 
 > [!NOTE]  
 > When using large `scrolloff` values i.e. larger than half of the number of lines on the screen, this plugin will override the `scrolloff` value to be half of the screen lines to avoid conflict from vim trying to prevent scrolloff when reaching end of file.
+

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -4,8 +4,16 @@ local mode_disabled = false
 local initial_scrolloff = vim.o.scrolloff
 local scrolloff = vim.o.scrolloff
 
+local function filetype_disabled()
+  if next(M.opts.enabled_filetypes) == nil then
+    return M.opts.disabled_filetypes[vim.o.filetype] == true
+  else
+    return M.opts.enabled_filetypes[vim.o.filetype] == nil
+  end
+end
+
 local function is_disabled()
-  return mode_disabled or M.opts.disabled_filetypes[vim.o.filetype] == true
+  return mode_disabled or filetype_disabled()
 end
 
 local function check_eof_scrolloff(ev)
@@ -46,6 +54,7 @@ local default_opts = {
   insert_mode = false,
   floating = true,
   disabled_filetypes = { 'terminal' },
+  enabled_filetypes = {},
   disabled_modes = { 't', 'nt' },
 }
 
@@ -88,6 +97,12 @@ M.setup = function(opts)
     disabled_filetypes_hashmap[val] = true
   end
   M.opts.disabled_filetypes = disabled_filetypes_hashmap
+
+  local enabled_filetypes_hashmap = {}
+  for _, val in pairs(M.opts.enabled_filetypes) do
+    enabled_filetypes_hashmap[val] = true
+  end
+  M.opts.enabled_filetypes = enabled_filetypes_hashmap
 
   local disabled_modes_hashmap = {}
   for _, val in pairs(M.opts.disabled_modes) do


### PR DESCRIPTION
This adds an `enabled_filetypes` option, and as stated in the readme, if you specify enabled_filetypes, everything is disabled except the enabled_filetypes.

I think this can be done with the pattern/autocmd option, but this way felt easier and more intuitive. My use case was I only wanted to enable this for a specific filetype (and maybe a few others as I encounter them).

If there's a better way to do this, feel free to close this PR and let me know.