### PR TITLE
Implement relative scrolloff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 scrollEOF.nvim
 ==============
-A simple and lightweight plugin to make scrolloff go past the end of the file. It uses the value of `scrolloff` to determine the amount of blank space to mimic the behaviour of scrolloff.
+A simple and lightweight plugin to make scrolloff go past the end of the file.
+It uses the value of `scrolloff` to determine the amount of blank space to mimic the behaviour of scrolloff.
+Alternatively, it can be configured to use a relative distance based on the window height.
 
 https://user-images.githubusercontent.com/23695024/216361766-34784d03-d9ae-4510-aee1-1536038c100f.mp4
 
@@ -29,7 +31,7 @@ Plug 'Aasim-A/scrollEOF.nvim'
 
 ### Setup
 #### Quick start
-Make sure that you set the `scrolloff` setting then add the following line to your Neovim config:
+Unless `scrollEOF` is configured to use a relative distance, make sure `scrolloff` is set before adding the following line to your Neovim config:
 
 Lua:
 ```lua
@@ -55,6 +57,10 @@ require('scrollEOF').setup({
   disabled_filetypes = { 'terminal' },
   -- List of modes to disable scrollEOF for. see https://neovim.io/doc/user/builtin.html#mode()
   disabled_modes = { 't', 'nt' },
+  -- If set to a number > 1, scrolloff is calculated as floor(window_height / n)
+  -- and dynamically updated whenever the window changes.
+  -- This ignores your existing global scrolloff value.
+  relative_scrolloff = 0,
 })
 ```
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -67,7 +67,7 @@ local vim_resized_cb = function()
   end
 
   scrolloff = half_win_height
-	vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
+  vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
 end
 
 M.setup = function(opts)

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -3,6 +3,7 @@ local M = {}
 local mode_disabled = false
 local initial_scrolloff = vim.o.scrolloff
 local scrolloff = vim.o.scrolloff
+local relative_scrolloff = 0
 
 local function is_disabled()
   return mode_disabled or M.opts.disabled_filetypes[vim.o.filetype] == true
@@ -47,6 +48,7 @@ local default_opts = {
   floating = true,
   disabled_filetypes = { 'terminal' },
   disabled_modes = { 't', 'nt' },
+  relative_scrolloff = 0,
 }
 
 local vim_resized_cb = function()
@@ -55,6 +57,12 @@ local vim_resized_cb = function()
   end
 
   local win_height = vim.fn.winheight(0)
+  if relative_scrolloff > 1 then
+    scrolloff = math.floor(win_height / relative_scrolloff)
+    vim.o.scrolloff = scrolloff
+    return -- use relative if set (legally) and ignore scrolloff
+  end
+
   local half_win_height = math.floor(win_height / 2)
 
   if initial_scrolloff < half_win_height then
@@ -99,6 +107,8 @@ M.setup = function(opts)
   if M.opts.insert_mode then
     table.insert(autocmds, 'CursorMovedI')
   end
+
+  relative_scrolloff = M.opts.relative_scrolloff
 
   local scrollEOF_group = vim.api.nvim_create_augroup('ScrollEOF', { clear = true })
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -120,7 +120,7 @@ M.setup = function(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'VimResized', 'BufEnter' }, {
+  vim.api.nvim_create_autocmd({ 'WinResized', 'WinEnter' }, {
     group = scrollEOF_group,
     pattern = M.opts.pattern,
     callback = vim_resized_cb,


### PR DESCRIPTION
Copied from the Issue description, didn't know this gets another description:

I have implemented this and fixed a related problem in the same branch: the 2 events `VimResized`, `BufEnter` on which a scrolloff recalculation happens should be `WinResized` and `WinEnter` (I think those were the intended ones anyways):

- `VimResized` doesn't fire when resizing windows; ex. if there are multiple horizontal windows and one is made smaller vertically `C-w20-`, then the recalculation isn't triggered (neither `relative`, nor safety half-of-height).
- `BufEnter` doesn't fire when a new window is entered that shows the same underlying buffer; ex. (horizontal) `:split`.

This is fixed with:

- `WinResized` fires after a window resizing (which would also happen on `VimResized`, at least if relevant).
- `WinEnter` fires when any other window is entered, regardless of underlying buffer.

Also there was a line indented with tab instead of spaces.

Closes #44 