### PR TITLE
Use window-local scrolloff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 scrollEOF.nvim
 ==============
-A simple and lightweight plugin to make scrolloff go past the end of the file. It uses the value of `scrolloff` to determine the amount of blank space to mimic the behaviour of scrolloff.
+A simple and lightweight plugin to make scrolloff go past the end of the file.
+It uses the value of `scrolloff` to determine the amount of blank space to mimic the behaviour of scrolloff.
+Alternatively, it can be configured to use a relative distance based on the window height.
 
 https://user-images.githubusercontent.com/23695024/216361766-34784d03-d9ae-4510-aee1-1536038c100f.mp4
 
@@ -29,7 +31,7 @@ Plug 'Aasim-A/scrollEOF.nvim'
 
 ### Setup
 #### Quick start
-Make sure that you set the `scrolloff` setting then add the following line to your Neovim config:
+Unless `scrollEOF` is configured to use a relative distance, make sure `scrolloff` is set before adding the following line to your Neovim config:
 
 Lua:
 ```lua
@@ -55,6 +57,10 @@ require('scrollEOF').setup({
   disabled_filetypes = { 'terminal' },
   -- List of modes to disable scrollEOF for. see https://neovim.io/doc/user/builtin.html#mode()
   disabled_modes = { 't', 'nt' },
+  -- If set to a number > 1, scrolloff is calculated as floor(window_height / n)
+  -- and dynamically updated whenever the window changes.
+  -- This ignores your existing global scrolloff value.
+  relative_scrolloff = 0,
 })
 ```
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local mode_disabled = false
 local initial_scrolloff = vim.o.scrolloff
-local scrolloff = vim.o.scrolloff
 local relative_scrolloff = 0
 
 local function is_disabled()
@@ -21,8 +20,8 @@ local function check_eof_scrolloff(ev)
     end
   end
 
+  local win_id = vim.api.nvim_get_current_win()
   if ev.event == 'WinScrolled' then
-    local win_id = vim.api.nvim_get_current_win()
     local win_event = vim.v.event[tostring(win_id)]
     if win_event ~= nil and win_event.topline <= 0 then
       return
@@ -33,6 +32,7 @@ local function check_eof_scrolloff(ev)
   local win_cur_line = vim.fn.winline()
   local visual_distance_to_eof = win_height - win_cur_line
 
+  local scrolloff = vim.wo[win_id].scrolloff
   if visual_distance_to_eof < scrolloff then
     local win_view = vim.fn.winsaveview()
     vim.fn.winrestview({
@@ -58,8 +58,7 @@ local vim_resized_cb = function()
 
   local win_height = vim.fn.winheight(0)
   if relative_scrolloff > 1 then
-    scrolloff = math.floor(win_height / relative_scrolloff)
-    vim.o.scrolloff = scrolloff
+    vim.wo.scrolloff = math.floor(win_height / relative_scrolloff)
     return -- use relative if set (legally) and ignore scrolloff
   end
 
@@ -68,14 +67,12 @@ local vim_resized_cb = function()
   if initial_scrolloff < half_win_height then
     if vim.o.scrolloff < initial_scrolloff then
       vim.o.scrolloff = initial_scrolloff
-      scrolloff = initial_scrolloff
     end
 
     return
   end
 
-  scrolloff = half_win_height
-  vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
+  vim.o.scrolloff = (win_height % 2 == 0 and half_win_height > 0) and half_win_height - 1 or half_win_height
 end
 
 M.setup = function(opts)

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -58,7 +58,7 @@ local function vim_resized_cb(ev)
 
   ---@type integer[]
   local win_ids = {}
-  if ev.event == "WinResized" then
+  if ev ~= nil and ev.event == "WinResized" then
     win_ids = vim.v.event.windows or {}
   else
     table.insert(win_ids, vim.api.nvim_get_current_win())
@@ -138,8 +138,12 @@ function M.setup(opts)
     callback = check_eof_scrolloff,
   })
 
+  vim_resized_cb()
   check_eof_scrolloff(nil)
-  vim.schedule(check_eof_scrolloff)
+  vim.schedule(function()
+    vim_resized_cb()
+    check_eof_scrolloff()
+  end)
 end
 
 return M

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -51,28 +51,37 @@ local default_opts = {
   relative_scrolloff = 0,
 }
 
-local function vim_resized_cb()
+local function vim_resized_cb(ev)
   if is_disabled() then
     return
   end
 
-  local win_height = vim.fn.winheight(0)
-  if relative_scrolloff > 1 then
-    vim.wo.scrolloff = math.floor(win_height / relative_scrolloff)
-    return -- use relative if set (legally) and ignore scrolloff
+  ---@type integer[]
+  local win_ids = {}
+  if ev.event == "WinResized" then
+    win_ids = vim.v.event.windows or {}
+  else
+    table.insert(win_ids, vim.api.nvim_get_current_win())
   end
 
-  local half_win_height = math.floor(win_height / 2)
-
-  if initial_scrolloff < half_win_height then
-    if vim.o.scrolloff < initial_scrolloff then
-      vim.o.scrolloff = initial_scrolloff
+  for _, id in ipairs(win_ids) do
+    local win_height = vim.fn.winheight(id)
+    if relative_scrolloff > 1 then
+      vim.wo[id].scrolloff = math.floor(win_height / relative_scrolloff)
+      goto continue
     end
 
-    return
-  end
+    local half_win_height = math.floor(win_height / 2)
+    if initial_scrolloff < half_win_height then
+      if vim.wo[id].scrolloff < initial_scrolloff then
+        vim.wo[id].scrolloff = initial_scrolloff
+      end
+      goto continue
+    end
 
-  vim.o.scrolloff = (win_height % 2 == 0 and half_win_height > 0) and half_win_height - 1 or half_win_height
+    vim.wo[id].scrolloff = (win_height % 2 == 0 and half_win_height > 0) and half_win_height - 1 or half_win_height
+    ::continue::
+  end
 end
 
 function M.setup(opts)

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -67,7 +67,7 @@ local vim_resized_cb = function()
   end
 
   scrolloff = half_win_height
-	vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
+  vim.o.scrolloff = (win_height % 2 == 0 and scrolloff > 0) and scrolloff - 1 or scrolloff
 end
 
 M.setup = function(opts)

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -30,7 +30,7 @@ local function check_eof_scrolloff(ev)
   local win_height = vim.fn.winheight(0)
   local win_cur_line = vim.fn.winline()
   local visual_distance_to_eof = win_height - win_cur_line
-  --- FIXME: when global scrolloff is much higher than winheight, window-local scrolloff somehow sets to -1
+  --- FIXME: when global scrolloff is set after Neovim startup to be much higher than winheight, window-local scrolloff somehow sets to -1
   local scrolloff = vim.wo[win_id].scrolloff
 
   if visual_distance_to_eof < scrolloff then

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -21,7 +21,7 @@ local function check_eof_scrolloff(ev)
   end
 
   local win_id = vim.api.nvim_get_current_win()
-  if ev.event == 'WinScrolled' then
+  if ev ~= nil and ev.event == 'WinScrolled' then
     local win_event = vim.v.event[tostring(win_id)]
     if win_event ~= nil and win_event.topline <= 0 then
       return
@@ -129,8 +129,8 @@ M.setup = function(opts)
     callback = check_eof_scrolloff,
   })
 
-  vim_resized_cb()
-  vim.defer_fn(vim_resized_cb, 0)
+  check_eof_scrolloff(nil)
+  vim.schedule(check_eof_scrolloff)
 end
 
 return M

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -51,7 +51,7 @@ local default_opts = {
   relative_scrolloff = 0,
 }
 
-local vim_resized_cb = function()
+local function vim_resized_cb()
   if is_disabled() then
     return
   end
@@ -75,7 +75,7 @@ local vim_resized_cb = function()
   vim.o.scrolloff = (win_height % 2 == 0 and half_win_height > 0) and half_win_height - 1 or half_win_height
 end
 
-M.setup = function(opts)
+function M.setup(opts)
   if opts == nil then
     opts = default_opts
   else

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local mode_disabled = false
-local initial_scrolloff = vim.o.scrolloff
 local relative_scrolloff = 0
 
 local function is_disabled()
@@ -31,8 +30,9 @@ local function check_eof_scrolloff(ev)
   local win_height = vim.fn.winheight(0)
   local win_cur_line = vim.fn.winline()
   local visual_distance_to_eof = win_height - win_cur_line
-
+  --- FIXME: when global scrolloff is much higher than winheight, window-local scrolloff somehow sets to -1
   local scrolloff = vim.wo[win_id].scrolloff
+
   if visual_distance_to_eof < scrolloff then
     local win_view = vim.fn.winsaveview()
     vim.fn.winrestview({
@@ -72,10 +72,8 @@ local function vim_resized_cb(ev)
     end
 
     local half_win_height = math.floor(win_height / 2)
-    if initial_scrolloff < half_win_height then
-      if vim.wo[id].scrolloff < initial_scrolloff then
-        vim.wo[id].scrolloff = initial_scrolloff
-      end
+    if vim.o.scrolloff < half_win_height then
+      vim.wo[id].scrolloff = vim.o.scrolloff
       goto continue
     end
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -3,6 +3,7 @@ local M = {}
 local mode_disabled = false
 local initial_scrolloff = vim.o.scrolloff
 local scrolloff = vim.o.scrolloff
+local relative_scrolloff = 0
 
 local function is_disabled()
   return mode_disabled or M.opts.disabled_filetypes[vim.o.filetype] == true
@@ -47,6 +48,7 @@ local default_opts = {
   floating = true,
   disabled_filetypes = { 'terminal' },
   disabled_modes = { 't', 'nt' },
+  relative_scrolloff = 0,
 }
 
 local vim_resized_cb = function()
@@ -55,6 +57,12 @@ local vim_resized_cb = function()
   end
 
   local win_height = vim.fn.winheight(0)
+  if relative_scrolloff > 1 then
+    scrolloff = math.floor(win_height / relative_scrolloff)
+    vim.o.scrolloff = scrolloff
+    return -- use relative if set (legally) and ignore scrolloff
+  end
+
   local half_win_height = math.floor(win_height / 2)
 
   if initial_scrolloff < half_win_height then
@@ -99,6 +107,8 @@ M.setup = function(opts)
   if M.opts.insert_mode then
     table.insert(autocmds, 'CursorMovedI')
   end
+
+  relative_scrolloff = M.opts.relative_scrolloff
 
   local scrollEOF_group = vim.api.nvim_create_augroup('ScrollEOF', { clear = true })
 

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -120,7 +120,7 @@ M.setup = function(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'VimResized', 'BufEnter' }, {
+  vim.api.nvim_create_autocmd({ 'WinResized', 'WinEnter' }, {
     group = scrollEOF_group,
     pattern = M.opts.pattern,
     callback = vim_resized_cb,

--- a/lua/scrollEOF.lua
+++ b/lua/scrollEOF.lua
@@ -100,7 +100,7 @@ M.setup = function(opts)
   end
   M.opts.disabled_modes = disabled_modes_hashmap
 
-  local autocmds = { 'CursorMoved', 'WinScrolled' }
+  local autocmds = { 'CursorMoved', 'WinScrolled', "WinNew", }
   if M.opts.insert_mode then
     table.insert(autocmds, 'CursorMovedI')
   end


### PR DESCRIPTION
- Builds upon #45
- Calculates window-local scrolloff from global scrolloff
- Uses window-local scrolloff to calculate topline in winrestview
- Fixes case when there is more than 1 window with different sizes (#47)